### PR TITLE
[FIX] Calculate amount wrong

### DIFF
--- a/l10n_th_bank_payment_export_scb/models/bank_payment_export_line.py
+++ b/l10n_th_bank_payment_export_scb/models/bank_payment_export_line.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from decimal import Decimal
+
 from odoo import api, fields, models
 
 from odoo.addons.base.models.res_bank import sanitize_account_number
@@ -103,7 +105,7 @@ class BankPaymentExportLine(models.Model):
 
     def _get_amount_no_decimal(self, amount, digits=False):
         if self.payment_export_id.bank == "SICOTHBK":
-            return str(int(amount * 1000)).zfill(digits)
+            return str(int(Decimal(str(amount)) * 1000)).zfill(digits)
         return super()._get_amount_no_decimal(amount, digits)
 
     def _get_payee_fax(self):


### PR DESCRIPTION
**Example**
amount: 64.35
Python calculate: amount * 1000 = 64.35 * 1000 = 64349.99999999999 (Wrong, it should be 64350)

Use class Decimal to calculate amount correct